### PR TITLE
feat: add an option for showing test paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ output dots for each test file, similar to a dot reporter.
 
 Note: this config is also available as an envar `JEST_SILENT_REPORTER_DOTS=true`
 
+### showPaths: boolean
+
+Sometimes it might come in handy to display the test suites' paths (i.e. when
+running tests in a terminal inside IDE for quicker file navigation).
+
+```json
+{
+  "reporters": [["jest-silent-reporter", { "showPaths": true }]]
+}
+```
+
+Note: this config is also available as an envar `JEST_SILENT_REPORTER_SHOW_PATHS=true`
+
 ## Screens
 
 #### All tests passed

--- a/SilentReporter.js
+++ b/SilentReporter.js
@@ -7,6 +7,7 @@ class SilentReporter {
     this._globalConfig = globalConfig;
     this.stdio = new StdIo();
     this.useDots = !!process.env.JEST_SILENT_REPORTER_DOTS || !!options.useDots;
+    this.showPaths = !!process.env.JEST_SILENT_REPORTER_SHOW_PATHS || !!options.showPaths;
   }
 
   onRunStart() {
@@ -29,6 +30,7 @@ class SilentReporter {
 
     if (!testResult.skipped) {
       if (testResult.failureMessage) {
+        if (this.showPaths) this.stdio.log('\n' + test.path);
         this.stdio.log('\n' + testResult.failureMessage);
       }
       const didUpdate = this._globalConfig.updateSnapshot === 'all';


### PR DESCRIPTION
This reporter is exactly what I've been looking for, but I missed the suites' paths for easier navigation 😉