### PR TITLE
Add option to show warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ output dots for each test file, similar to a dot reporter.
 }
 ```
 
-Note: this config is also available as an environment variable `JEST_SILENT_REPORTER_DOTS=true`
+### showWarnings: boolean
+
+Warnings are supressed by default, use `showWarnings` to log them.
+
+```json
+{
+  "reporters": [["jest-silent-reporter", { "showWarnings": true }]]
+}
+```
+
+Note: these options are also available as environment variables `JEST_SILENT_REPORTER_DOTS=true` and `JEST_SILENT_REPORTER_SHOW_WARNINGS=true`
 
 ## Screenshots
 

--- a/SilentReporter.js
+++ b/SilentReporter.js
@@ -7,6 +7,9 @@ class SilentReporter {
     this._globalConfig = globalConfig;
     this.stdio = new StdIo();
     this.useDots = !!process.env.JEST_SILENT_REPORTER_DOTS || !!options.useDots;
+    this.showWarnings =
+      !!process.env.JEST_SILENT_REPORTER_SHOW_WARNINGS ||
+      !!options.showWarnings;
   }
 
   onRunStart() {
@@ -30,6 +33,12 @@ class SilentReporter {
     if (!testResult.skipped) {
       if (testResult.failureMessage) {
         this.stdio.log('\n' + testResult.failureMessage);
+      }
+      if (testResult.console && this.showWarnings) {
+        testResult.console
+          .filter(entry => entry.type === 'warn' && entry.message)
+          .map(entry => entry.message)
+          .forEach(this.stdio.log);
       }
       const didUpdate = this._globalConfig.updateSnapshot === 'all';
       const snapshotStatuses = helpers.getSnapshotStatus(


### PR DESCRIPTION
This change adds a new option called `showWarnings` to avoid suppressing warnings. I've faced this problem when trying to use this reporter combined with [jest-runner-eslint](https://github.com/jest-community/jest-runner-eslint). In my case, we didn't want our warnings being suppressed during our build process but we also didn't want the entire default jest reporter output. Also, according to #7 this might be a common need. 

Hopefully, this code covers any possible warning, let me know if I missed something.

closes #7 