### PR TITLE
show file path for obsolete snapshots

### DIFF
--- a/SilentReporter.js
+++ b/SilentReporter.js
@@ -7,7 +7,8 @@ class SilentReporter {
     this._globalConfig = globalConfig;
     this.stdio = new StdIo();
     this.useDots = !!process.env.JEST_SILENT_REPORTER_DOTS || !!options.useDots;
-    this.showPaths = !!process.env.JEST_SILENT_REPORTER_SHOW_PATHS || !!options.showPaths;
+    this.showPaths =
+      !!process.env.JEST_SILENT_REPORTER_SHOW_PATHS || !!options.showPaths;
     this.showWarnings =
       !!process.env.JEST_SILENT_REPORTER_SHOW_WARNINGS ||
       !!options.showWarnings;
@@ -32,17 +33,22 @@ class SilentReporter {
     }
 
     if (!testResult.skipped) {
-      if (testResult.failureMessage) {
-        if (this.showPaths) this.stdio.log('\n' + test.path);
-        this.stdio.log('\n' + testResult.failureMessage);
+      const didUpdate = this._globalConfig.updateSnapshot === 'all';
+      const hasUncheckedSnapshots =
+        !didUpdate && testResult.snapshot && testResult.snapshot.unchecked;
+      const hasFailures = testResult.failureMessage || hasUncheckedSnapshots;
+
+      if (this.showPaths && hasFailures) {
+        this.stdio.log('\n' + test.path);
       }
+      if (testResult.failureMessage)
+        this.stdio.log('\n' + testResult.failureMessage);
       if (testResult.console && this.showWarnings) {
         testResult.console
           .filter(entry => entry.type === 'warn' && entry.message)
           .map(entry => entry.message)
           .forEach(this.stdio.log);
       }
-      const didUpdate = this._globalConfig.updateSnapshot === 'all';
       const snapshotStatuses = helpers.getSnapshotStatus(
         testResult.snapshot,
         didUpdate

--- a/SilentReporter.js
+++ b/SilentReporter.js
@@ -34,9 +34,17 @@ class SilentReporter {
 
     if (!testResult.skipped) {
       const didUpdate = this._globalConfig.updateSnapshot === 'all';
-      const hasUncheckedSnapshots =
-        !didUpdate && testResult.snapshot && testResult.snapshot.unchecked;
-      const hasFailures = testResult.failureMessage || hasUncheckedSnapshots;
+      let hasSnapshotFailures = false;
+      if (testResult.snapshot) {
+        if (!didUpdate && testResult.snapshot.unchecked) {
+          hasSnapshotFailures = true;
+        }
+        if (testResult.snapshot.unmatched) {
+          hasSnapshotFailures = true;
+        }
+      }
+
+      const hasFailures = testResult.failureMessage || hasSnapshotFailures;
 
       if (this.showPaths && hasFailures) {
         this.stdio.log('\n' + test.path);


### PR DESCRIPTION
If a test fail due to obsolete snapshot, it's impossible to tell which file has the snapshots.
The filePath flag only address an actual test failure (via asserting `testResult.failureMessage`).
This PR adds support to show filePath for obsolete snapshots as well.
This tries to solve the same problem reported here https://github.com/rickhanlonii/jest-silent-reporter/issues/15 but instead of showing the report, simply show the file path for where the error occurred.

## The result
```
$ yarn test:ci 
yarn run v1.21.1
$ JEST_SILENT_REPORTER_SHOW_WARNINGS=true JEST_SILENT_REPORTER_SHOW_PATHS=true <some path> --ci --silent --reporters=jest-silent-reporter --reporters=jest-junit

<the file path with the error>
 › 1 obsolete snapshot found.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```