### PR TITLE
Include console.error messages when showWarnings is enabled

### DIFF
--- a/SilentReporter.js
+++ b/SilentReporter.js
@@ -53,7 +53,7 @@ class SilentReporter {
         this.stdio.log('\n' + testResult.failureMessage);
       if (testResult.console && this.showWarnings) {
         testResult.console
-          .filter(entry => entry.type === 'warn' && entry.message)
+          .filter(entry => ['error', 'warn'].includes(entry.type) && entry.message)
           .map(entry => entry.message)
           .forEach(this.stdio.log);
       }


### PR DESCRIPTION
This would cover when `console.error` has been used for warnings, like the Formik ones mentioned in https://github.com/rickhanlonii/jest-silent-reporter/issues/25