### PR TITLE
add showErrors option to suppress test errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Warnings are supressed by default, use `showWarnings` to log them.
 
 Note: this config is also available as an environment variable `JEST_SILENT_REPORTER_SHOW_WARNINGS=true`.
 
+### showErrors: boolean (default: true)
+
+Errors are logged by default, use `showErrors` to suppress them.
+
+```json
+{
+  "reporters": [["jest-silent-reporter", { "showErrors": false }]]
+}
+```
+
+Note: this config is also available as an environment variable `JEST_SILENT_REPORTER_SHOW_ERRORS=false`.
 
 ### showPaths: boolean
 

--- a/SilentReporter.js
+++ b/SilentReporter.js
@@ -12,6 +12,12 @@ class SilentReporter {
     this.showWarnings =
       !!process.env.JEST_SILENT_REPORTER_SHOW_WARNINGS ||
       !!options.showWarnings;
+    this.showErrors =
+      // showErrors defaults true if unset
+      !!(
+        (process.env.JEST_SILENT_REPORTER_SHOW_ERRORS || options.showErrors)
+        ?? true
+      )
   }
 
   onRunStart() {
@@ -46,10 +52,10 @@ class SilentReporter {
 
       const hasFailures = testResult.failureMessage || hasSnapshotFailures;
 
-      if (this.showPaths && hasFailures) {
+      if (this.showPaths && hasFailures && this.showErrors) {
         this.stdio.log('\n' + test.path);
       }
-      if (testResult.failureMessage)
+      if (testResult.failureMessage && this.showErrors)
         this.stdio.log('\n' + testResult.failureMessage);
       if (testResult.console && this.showWarnings) {
         testResult.console


### PR DESCRIPTION
Useful e.g. when only interested in coverage report

Defaults to true if unset to preserve backwards-compatibility

Thanks for handy module!